### PR TITLE
Fix padding on LibraryView

### DIFF
--- a/sigmap-ios/Views/LibraryView.swift
+++ b/sigmap-ios/Views/LibraryView.swift
@@ -58,7 +58,7 @@ struct LibraryView: View {
                             }
                             
                         }
-                    }.padding(.top, 100).padding(.bottom, 100)
+                    }.padding(.top, 110).padding(.bottom, 110)
                 }
                     
                 Divider()


### PR DESCRIPTION
Small padding fix to LibraryView that prevents the Map elements from going over the dividers at the top and bottom.